### PR TITLE
Add resource to log

### DIFF
--- a/G-Research.OpenTelemetry.Processor.Partial.Tests/CapturingLogExporter.cs
+++ b/G-Research.OpenTelemetry.Processor.Partial.Tests/CapturingLogExporter.cs
@@ -1,0 +1,18 @@
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+
+public class CapturingLogExporter(Resource resource) : BaseExporter<LogRecord>
+{
+    public readonly List<(LogRecord Log, Resource Resource)> Exported = [];
+
+    public override ExportResult Export(in Batch<LogRecord> batch)
+    {
+        foreach (var log in batch)
+        {
+            Exported.Add((log, resource));
+        }
+
+        return ExportResult.Success;
+    }
+}

--- a/G-Research.OpenTelemetry.Processor.Partial/Example.cs
+++ b/G-Research.OpenTelemetry.Processor.Partial/Example.cs
@@ -42,9 +42,8 @@ public class Example
 
         var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddSource("activitySource")
-            .SetResourceBuilder(resourceBuilder)
             .AddProcessor(new PartialActivityProcessor(logExporter: otlpLogExporter,
-                heartbeatIntervalMilliseconds: 1000))
+                resourceBuilder: resourceBuilder, heartbeatIntervalMilliseconds: 1000))
             .AddProcessor(new SimpleActivityExportProcessor(otlpExporter))
             .Build();
 


### PR DESCRIPTION
- expanded PartialActivityProcessor constructor to accept ResourceBuilder
- ResourceBuilder is set during LoggerFactory creation
- modified example
- added tests (exporter for tests pursposes has to be created because log record does not have resource and it has to be accessed on exporter level)